### PR TITLE
Fixed bug so application doesn't crash.

### DIFF
--- a/src/main/java/com/example/springbootproject/controller/ChainController.java
+++ b/src/main/java/com/example/springbootproject/controller/ChainController.java
@@ -2,7 +2,6 @@ package com.example.springbootproject.controller;
 
 import com.example.springbootproject.entity.Chain;
 import com.example.springbootproject.projection.ChainName;
-import com.example.springbootproject.projection.StoreName;
 import com.example.springbootproject.repository.ChainRepository;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -22,8 +21,8 @@ public class ChainController {
     }
 
     @GetMapping("/{id}")
-    Chain getName(@PathVariable long id) {
-        return repository.findById(id).orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
+    ChainName getName(@PathVariable long id) {
+        return repository.findNameById(id);
     }
 
     @GetMapping


### PR DESCRIPTION
The method now uses projection instead. It does not crash, but if we enter an id that does not exist it returns just an empty body.

Closes #66 